### PR TITLE
stripedRows + selection fix

### DIFF
--- a/packages/primevue/src/classic/datatable/index.ts
+++ b/packages/primevue/src/classic/datatable/index.ts
@@ -344,7 +344,7 @@ export default {
             { 'bg-highlight': context.selected },
             { 'bg-surface-0 text-surface-600 dark:text-white/80 dark:bg-surface-900': !context.selected },
             { 'font-bold bg-surface-0 dark:bg-surface-900 z-20': props.frozenRow },
-            { 'odd:bg-surface-0 odd:text-surface-600 dark:odd:text-surface-0 dark:even:text-surface-0 dark:odd:bg-surface-800 even:bg-surface-50 even:text-surface-600 dark:even:bg-surface-900': context.stripedRows },
+            { 'odd:bg-surface-0 odd:text-surface-600 dark:odd:text-surface-0 dark:even:text-surface-0 dark:odd:bg-surface-800 even:bg-surface-50 even:text-surface-600 dark:even:bg-surface-900': context.stripedRows && !context.selected },
             // State
             { 'hover:bg-surface-300/20 dark:hover:bg-surface-700/50': (props.selectionMode && !context.selected) || parent.instance.rowHover },
 

--- a/packages/primevue/src/stories/DataTable.story.vue
+++ b/packages/primevue/src/stories/DataTable.story.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
 import { ref } from 'vue'
 
 const products = ref([
@@ -28,10 +28,10 @@ const selectedProduct = ref()
         </Variant>
 
         <Variant title="Selection">
-            <DataTable 
-                :value="products" 
-                v-model:selection="selectedProduct" 
-                selectionMode="single" 
+            <DataTable
+                :value="products"
+                v-model:selection="selectedProduct"
+                selectionMode="single"
                 tableStyle="min-width: 50rem"
             >
                 <Column field="code" header="Code"></Column>
@@ -53,5 +53,22 @@ const selectedProduct = ref()
             </DataTable>
             <div class="text-gray-300 mt-2">Table with striped rows for better readability</div>
         </Variant>
+
+        <Variant title="Striped+Selection">
+            <DataTable
+                :value="products"
+                v-model:selection="selectedProduct"
+                selectionMode="single"
+                tableStyle="min-width: 50rem"
+                stripedRows
+            >
+                <Column field="code" header="Code"></Column>
+                <Column field="name" header="Name"></Column>
+                <Column field="category" header="Category"></Column>
+                <Column field="price" header="Price"></Column>
+                <Column field="quantity" header="Quantity"></Column>
+            </DataTable>
+            <div class="text-gray-300 mt-2">Selected: {{ selectedProduct?.name || 'None' }}</div>
+        </Variant>
     </Story>
-</template> 
+</template>


### PR DESCRIPTION
Fixed issue where `bg-highlight` was not being applied correctly to DataTable with stripedRows. Also, added `Striped+Selection` variant to the Storybook

## Before
https://github.com/user-attachments/assets/463f0657-461b-4bfb-83e6-bc5f53b7bb11

## After
https://github.com/user-attachments/assets/e40f35c0-4e2d-416e-b83d-61ec5259bda9

