### PR TITLE
ContextMenu flickering fix

### DIFF
--- a/packages/primevue/src/classic/contextmenu/index.ts
+++ b/packages/primevue/src/classic/contextmenu/index.ts
@@ -36,7 +36,7 @@ export default {
             // Colors
             {
                 'text-surface-500 dark:text-white/70': !context.focused && !context.active,
-                'text-surface-500 dark:text-white/70 bg-surface-200 dark:bg-surface-600/90': context.focused && !context.active,
+                'text-surface-500 dark:text-white/70 bg-surface-100 dark:bg-[rgba(255,255,255,0.03)]': context.focused && !context.active,
                 'bg-highlight text-highlight-contrast': (context.focused && context.active) || context.active || (!context.focused && context.active)
             },
 


### PR DESCRIPTION
There is a 2px gap between context menu item rows where browser doesn't trigger `hover` anymore but for primevue it's still `context.focused`. Because a different bg color was used for `context.focused` (for keyboard navigation) it created weird bg flickering. Fixed this by using the same bg color for the focused state and hover.

I don't think there's a other fix to this, it's probably intended primevue behavior because similar thing happens on their docs page but they use same color for focused state so the flickering doesn't happen

https://github.com/user-attachments/assets/15c7d2b9-7efd-436c-bb14-df17aad2a72d



## Before

https://github.com/user-attachments/assets/89a5deb1-1c74-45a4-9d8a-99619ecd7710


## After

https://github.com/user-attachments/assets/efe3c7e1-f7cf-464f-b020-0b27febc3aca

